### PR TITLE
Bump default Vagrant version to 2.2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,6 @@ matrix:
     - rvm: 2.4.4
       env: TEST_VAGRANT_VERSION=v2.1.2
     - rvm: 2.4.4
+      env: TEST_VAGRANT_VERSION=v2.2.2
+    - rvm: 2.4.4
       env: TEST_VAGRANT_VERSION=HEAD

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 require 'rubygems/version'
 
-vagrant_branch = ENV['TEST_VAGRANT_VERSION'] || 'v2.1.2'
+vagrant_branch = ENV['TEST_VAGRANT_VERSION'] || 'v2.2.2'
 vagrant_version = nil
 
 group :plugins do
@@ -25,6 +25,7 @@ group :test do
     gem 'vagrant-spec', :git => 'https://github.com/hashicorp/vagrant-spec.git',
       :ref => '9413ab2'
   end
+  gem 'rake'
 end
 
 eval_gemfile "#{__FILE__}.local" if File.exists? "#{__FILE__}.local"

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,5 @@
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new(:spec)
+
+task :default => [:spec]


### PR DESCRIPTION
This commit adds testing for Vagrant 2.2.2 and updates the default to
2.2.2.